### PR TITLE
Add SIMAP award and qualification criteria

### DIFF
--- a/simap_agent/enricher.py
+++ b/simap_agent/enricher.py
@@ -109,6 +109,16 @@ def enrich(detail: Dict[str, Any], profile: Dict[str, Any]) -> Dict[str, Any]:
     proj = data.get("project", {})
     for k in TARGET_KEYS:
         proj.setdefault(k, None)
+
+    # Pass through qualification and award criteria if present in the detail
+    qual = detail.get("qualificationCriteria") or []
+    if qual:
+        data["qualificationCriteria"] = qual
+
+    award = detail.get("awardCriteria") or []
+    if award:
+        data["awardCriteria"] = award
+
     return data
 
 

--- a/simap_agent/main.py
+++ b/simap_agent/main.py
@@ -64,8 +64,35 @@ def main() -> None:
             f":star: *Apply Score:* *{score}*\n\n"
             f":page_facing_up: *Zusammenfassung:*\n>{summary}\n\n"
             f":pushpin: *CPV:* `{(det.get('base') or {}).get('cpvCode', {}).get('code')}`\n"
-            "––––––––––––––––––––––––––––––––––––––––––––––––––"
         )
+
+        qual = enrich_data.get("qualificationCriteria") or []
+        if qual:
+            text += ":bookmark_tabs: *Eignungskriterien:*"
+            for c in qual:
+                title = (c.get("title") or {}).get("de")
+                if not title:
+                    continue
+                desc = (c.get("description") or {}).get("de") or ""
+                text += f"\n• *{title}*"
+                if desc:
+                    text += f" – {desc}"
+            text += "\n\n"
+
+        award = enrich_data.get("awardCriteria") or []
+        if award:
+            text += ":trophy: *Zuschlagskriterien:*"
+            for a in award:
+                title = (a.get("title") or {}).get("de")
+                if not title:
+                    continue
+                weight = a.get("weighting")
+                text += f"\n• *{title}*"
+                if weight is not None:
+                    text += f" – Gewichtung {weight}%"
+            text += "\n"
+
+        text += "––––––––––––––––––––––––––––––––––––––––––––––––––"
         print(text)
         #post_message(text)
 


### PR DESCRIPTION
## Summary
- keep qualification and award criteria from SIMAP project details
- include these criteria in Slack messages

## Testing
- `python -m py_compile simap_agent/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847eab37a7883208fd7ad7610cc1d60