### PR TITLE
Fix running main.py directly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+python-dotenv
+openai
+requests

--- a/simap_agent/main.py
+++ b/simap_agent/main.py
@@ -1,5 +1,10 @@
 import json
 import logging
+import os
+import sys
+
+# Ensure package imports work when executed directly
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from simap_agent import config
 from simap_agent.simap_client import fetch_project_summaries, fetch_project_details


### PR DESCRIPTION
## Summary
- adjust `sys.path` for running the package directly
- add `requirements.txt`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python simap_agent/main.py` *(fails: Missing environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_6847ebce00a483208a473b25d41f1c51