### PR TITLE
Improve Slack missing info formatting

### DIFF
--- a/simap_agent/slack_client.py
+++ b/simap_agent/slack_client.py
@@ -52,8 +52,10 @@ def format_slack_blocks(proj: Dict[str, Any]) -> List[Dict[str, Any]]:
         f"\n:page_facing_up: *Zusammenfassung:*\n>{summary}\n\n"
         f":calendar:   •   *Q&A:* {qa_dl}   •   *Frist:* {offer_dl}   •   *Start:* {start} \n"
         f"\n:pushpin: *CPV:* `{cpv_code}` – {cpv_label}\n"
-        f"\n:mag: *Fehlende Infos:* {missing_str}\n"
     )
+
+    if missing:
+        text += f"\n:mag: *Fehlende Infos:* {missing_str}\n"
 
     qual_summary = proj.get("qualificationCriteriaSummary")
     qual = proj.get("qualificationCriteria") or []

--- a/tests/test_simap.py
+++ b/tests/test_simap.py
@@ -40,6 +40,29 @@ def test_format_slack_blocks_basic():
     section_text = next(b for b in blocks if b.get("type") == "section")["text"]["text"]
     assert "Projekt" in section_text
     assert "Engineering" in section_text
+    assert "Fehlende Infos" not in section_text
+
+
+def test_format_slack_blocks_missing_info():
+    proj = {
+        "team": "Engineering",
+        "project": {
+            "title_de": "Projekt",
+            "customer": "Kunde",
+            "projectNumber": "123",
+            "projectId": "abc",
+            "offerDeadline": "2024-12-31",
+            "contract_start": "2025-01-15",
+            "qna_deadline": "2024-12-01",
+            "cpvCode": {"code": "48000000", "label_de": "Software"},
+        },
+        "apply_score": 7,
+        "summary": "Kurzfassung",
+        "missing_info": ["Ort"],
+    }
+    blocks = slack_client.format_slack_blocks(proj)
+    section_text = next(b for b in blocks if b.get("type") == "section")["text"]["text"]
+    assert "Fehlende Infos" in section_text
 
 
 def test_enrich_missing_info(monkeypatch):


### PR DESCRIPTION
## Summary
- show the 'Fehlende Infos' line only when there is missing info
- add tests for the new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68485130680883209277474bbd254132