### PR TITLE
Adjust Azure Functions workspace paths

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
-    "azureFunctions.deploySubpath": "azure_function",
+    "azureFunctions.deploySubpath": ".",
     "azureFunctions.scmDoBuildDuringDeployment": true,
     "azureFunctions.pythonVenv": ".venv",
     "azureFunctions.projectLanguage": "Python",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,17 +1,17 @@
 {
 	"version": "2.0.0",
 	"tasks": [
-		{
-			"type": "func",
-			"label": "func: host start",
-			"command": "host start",
-			"problemMatcher": "$func-python-watch",
-			"isBackground": true,
-			"dependsOn": "pip install (functions)",
-			"options": {
-				"cwd": "${workspaceFolder}/azure_function"
-			}
-		},
+                {
+                        "type": "func",
+                        "label": "func: host start",
+                        "command": "host start",
+                        "problemMatcher": "$func-python-watch",
+                        "isBackground": true,
+                        "dependsOn": "pip install (functions)",
+                        "options": {
+                                "cwd": "${workspaceFolder}"
+                        }
+                },
 		{
 			"label": "pip install (functions)",
 			"type": "shell",
@@ -25,9 +25,10 @@
 				"command": "${config:azureFunctions.pythonVenv}/bin/python -m pip install -r requirements.txt"
 			},
 			"problemMatcher": [],
-			"options": {
-				"cwd": "${workspaceFolder}/azure_function"
-			}
-		}
-	]
+                        "options": {
+                                "cwd": "${workspaceFolder}"
+                        }
+                }
+        ]
 }
+


### PR DESCRIPTION
## Summary
- deploy the whole repo when publishing Azure Functions
- run tasks from the repository root instead of `azure_function`

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q`
- `func azure functionapp publish test --no-build` *(fails: Unable to connect to Azure)*

------
https://chatgpt.com/codex/tasks/task_e_684950e252e48320b0cb47850df75848