### PR TITLE
Switch to Azure OpenAI endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SIMAP Agent
 
-Dieses Projekt automatisiert das Abrufen und Aufbereiten von Ausschreibungen aus [SIMAP](https://simap.ch). Die Daten werden mit Hilfe von OpenAI angereichert und anschliessend als formatierte Nachrichten an Slack gesendet.
+Dieses Projekt automatisiert das Abrufen und Aufbereiten von Ausschreibungen aus [SIMAP](https://simap.ch). Die Daten werden mit Hilfe von Azure OpenAI angereichert und anschliessend als formatierte Nachrichten an Slack gesendet.
 
 ## Installation
 ```bash
@@ -11,15 +11,17 @@ pip install -r requirements.txt
 `.env`-Datei beinhaltet folgende Variablen :
 
 - `SLACK_WEBHOOK_URL` – Slack Incoming Webhook
-- `OPENAI_API_KEY` – OpenAI API key
-- Optional: `SIMAP_BASE_URL`, `SIMAP_SEARCH_ENDPOINT`, `SIMAP_DETAIL_ENDPOINT_TEMPLATE`, `COMPANY_PROFILE_FILE`, `CPV_CODES`, `APPLY_SCORE_THRESHOLD`
+- `OPENAI_API_KEY` – Azure OpenAI API key
+- Optional: `AZURE_OPENAI_ENDPOINT`, `OPENAI_API_VERSION`, `SIMAP_BASE_URL`, `SIMAP_SEARCH_ENDPOINT`, `SIMAP_DETAIL_ENDPOINT_TEMPLATE`, `COMPANY_PROFILE_FILE`, `CPV_CODES`, `APPLY_SCORE_THRESHOLD`
+
+Standardwerte für `AZURE_OPENAI_ENDPOINT` und `OPENAI_API_VERSION` sind bereits hinterlegt.
 
 
 ## Nutzung
 ```bash
 python -m simap_agent
 ```
-Das Skript ruft aktuelle Projekte ab, nutzt OpenAI zur Anreicherung und postet die Ergebnisse in Slack. Die angereicherten Daten werden ebenfalls in `enriched_projects.json` geschrieben.
+Das Skript ruft aktuelle Projekte ab, nutzt Azure OpenAI zur Anreicherung und postet die Ergebnisse in Slack. Die angereicherten Daten werden ebenfalls in `enriched_projects.json` geschrieben.
 
 ## Deployment
 Das Projekt läuft in einer Azure Function, die nach einem täglich um 7:00 nach einen festen Zeitplan ausgeführt wird:

--- a/simap_agent/config.py
+++ b/simap_agent/config.py
@@ -21,6 +21,11 @@ SIMAP_DETAIL_ENDPOINT_TEMPLATE = os.getenv(
 )
 SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+AZURE_OPENAI_ENDPOINT = os.getenv(
+    "AZURE_OPENAI_ENDPOINT",
+    "https://dataai-opai-openai-weu-001.cognitiveservices.azure.com/",
+)
+OPENAI_API_VERSION = os.getenv("OPENAI_API_VERSION", "2025-01-01-preview")
 COMPANY_PROFILE_FILE = os.getenv("COMPANY_PROFILE_FILE", "company_profile.json")
 CPV_CODES = os.getenv("CPV_CODES", "48000000,72000000").split(",")
 # Minimum apply score required for posting a project to Slack

--- a/simap_agent/enricher.py
+++ b/simap_agent/enricher.py
@@ -4,13 +4,17 @@ import json
 import logging
 from typing import Any, Dict, List
 
-from openai import OpenAI
+from openai import AzureOpenAI
 
 from simap_agent import config
 
 logger = logging.getLogger(__name__)
 
-openai_client = OpenAI(api_key=config.OPENAI_API_KEY)
+openai_client = AzureOpenAI(
+    api_key=config.OPENAI_API_KEY,
+    azure_endpoint=config.AZURE_OPENAI_ENDPOINT,
+    api_version=config.OPENAI_API_VERSION,
+)
 
 
 def summarize_criteria(criteria: List[Dict[str, Any]], name: str) -> str:

--- a/tests/test_simap.py
+++ b/tests/test_simap.py
@@ -10,6 +10,11 @@ import importlib
 # Ensure required env vars for config
 os.environ.setdefault("SLACK_WEBHOOK_URL", "http://example.com")
 os.environ.setdefault("OPENAI_API_KEY", "dummy")
+os.environ.setdefault(
+    "AZURE_OPENAI_ENDPOINT",
+    "https://dataai-opai-openai-weu-001.cognitiveservices.azure.com/",
+)
+os.environ.setdefault("OPENAI_API_VERSION", "2025-01-01-preview")
 os.environ.setdefault("APPLY_SCORE_THRESHOLD", "7")
 
 import simap_agent.config as config


### PR DESCRIPTION
## Summary
- configure Azure OpenAI endpoint and default API version
- update enricher to use `AzureOpenAI`
- document new environment variables
- ensure tests define Azure variables

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849680e5ce88320aadbd4e20fa10519