### PR TITLE
Switch completions to GPT‑4o model

### DIFF
--- a/simap_agent/enricher.py
+++ b/simap_agent/enricher.py
@@ -23,7 +23,7 @@ def summarize_criteria(criteria: List[Dict[str, Any]], name: str) -> str:
         return ""
     logger.debug("Summarizing %s via OpenAI", name)
     resp = openai_client.chat.completions.create(
-        model="o4-mini",
+        model="gpt-4o",
         messages=[
             {
                 "role": "system",
@@ -128,7 +128,7 @@ def enrich(detail: Dict[str, Any], profile: Dict[str, Any]) -> Dict[str, Any]:
     )
     logger.debug("Calling OpenAI for project %s", detail.get("id"))
     resp = openai_client.chat.completions.create(
-        model="o4-mini",
+        model="gpt-4o",
         messages=[
             {"role": "system", "content": system_content},
             {


### PR DESCRIPTION
## Summary
- use the `gpt-4o` model when calling OpenAI completions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68497368dfec8320968e971fa3d6e486